### PR TITLE
chore: Update Android SDK from 5.11.0 to 5.11.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,5 +26,5 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.11.0'
+    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.11.1'
 }


### PR DESCRIPTION
## Summary
Bumps the LaunchDarkly Android Client SDK dependency from `5.11.0` to `5.11.1` (patch release).

## Review & Testing Checklist for Human
- [x] Verify CI build passes — this is an Android project and the build was not tested locally
- [x] Confirm `5.11.1` is the latest published version of `com.launchdarkly:launchdarkly-android-client-sdk` on Maven Central
- [ ] Build and run the example app on an emulator or device to confirm it initializes the SDK and evaluates a flag successfully

### Notes
Single-line patch version bump. No API changes expected. No README update needed since it does not reference the SDK version.

Link to Devin session: https://app.devin.ai/sessions/707962703f2540d5b8c92734ecf9e33a
Requested by: @kinyoklion