### PR TITLE
chore: update launchdarkly-android-client-sdk to 5.12.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,5 +26,5 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.11.1'
+    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.12.0'
 }


### PR DESCRIPTION
## Summary
Update `launchdarkly-android-client-sdk` from pinned version `5.11.1` to `5.12.0` (the latest release).

The 5.12.0 release removes the Kotlin stdlib dependency from the SDK itself. No API changes or deprecations.

## Review & Testing Checklist for Human
- [ ] Build the project with `./gradlew assembleDebug` to verify it compiles
- [ ] Run the app on an Android device/emulator and verify flag evaluation works

### Notes
- The version constraint pattern remains pinned to an exact version as before
- No deprecated API usage was found in the example code
- The SDK changelog: https://github.com/launchdarkly/android-client-sdk/releases/tag/5.12.0

Link to Devin session: https://app.devin.ai/sessions/54f519e98f9c415cb2bb949c0888e8a1
Requested by: @kinyoklion