### PR TITLE
chore: update android-client-sdk from 5.12.2 to 5.13.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,5 +26,5 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.12.2'
+    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.13.1'
 }


### PR DESCRIPTION
## Summary

Bumps `launchdarkly-android-client-sdk` from 5.12.2 to 5.13.1 in `app/build.gradle`.

No code changes required — the example uses modern APIs (`LDContext`, `AutoEnvAttributes`) with no deprecated usage detected.

Link to Devin session: https://app.devin.ai/sessions/6d5d0c867c1547debde25a4a123390f4
Requested by: @kinyoklion