### PR TITLE
chore: migrate to LDClient.init timeout variant

### DIFF
--- a/app/src/main/java/com/launchdarkly/hello_android/MainApplication.java
+++ b/app/src/main/java/com/launchdarkly/hello_android/MainApplication.java
@@ -38,7 +38,10 @@ public class MainApplication extends Application {
                     .build();
         }
 
-        LDClient.init(this, ldConfig, context);
+        // Initialize the client and wait up to 5 seconds for it to receive the latest flag
+        // values. If initialization does not complete within the timeout, the client is still
+        // returned and can be used with cached values.
+        LDClient.init(this, ldConfig, context, 5);
     }
 
     private boolean isUserLoggedIn() {


### PR DESCRIPTION
## Summary

The example already targets the latest stable `com.launchdarkly:launchdarkly-android-client-sdk` (`5.13.1`, latest on Maven Central), so no version bump was needed. The only change is migrating away from a deprecated SDK API:

`LDClient.init(app, config, context)` (3-arg, returns `Future<LDClient>`) is `@Deprecated` in the current SDK — initializing without a timeout is no longer recommended. Migrated to the documented replacement `init(Application, LDConfig, LDContext, int startWaitSeconds)`:

```diff
- LDClient.init(this, ldConfig, context);
+ LDClient.init(this, ldConfig, context, 5); // wait up to 5s for initialization
```

No other deprecated SDK APIs are in use (`LDClient.get`, `boolVariation`, `registerFeatureFlagListener`, `flush`, `LDConfig.Builder(AutoEnvAttributes)`, `LDContext.builder`).

## Verification

`./gradlew :app:assembleDebug` compiles cleanly against SDK 5.13.1. I was also able to boot a headless Android 34 emulator on this Linux VM and run the app: it initialized the client and displayed `Feature flag 'my-boolean-flag' is false`, confirming the new `init` call works at runtime.

![app running](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaGVBMWRpc2owVHVLd2VVSyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19oZUExZGlzajBUdUt3ZVVLL2RiNzE0NjljLWQyMzktNGZkYy04OTkyLTg2ZWYxNjAxZmUzNSIsImlhdCI6MTc4MzMzMDg4NCwiZXhwIjoxNzgzOTM1Njg0LCJmaWxlbmFtZSI6ImFwcF9zY3JlZW4zLnBuZyJ9.aoegi5lLdXAPFU_40PLa9hF8E4X3-4apt4VSqixgpPg)

The "Process/System UI isn't responding" dialog is an emulator SystemUI ANR under software rendering (swiftshader), unrelated to the app — the app UI (title `hello-android`, flag evaluation text) renders correctly behind it.

## Notes
- No README changes needed (it does not reference an SDK version or platform requirement that changed).
- No secrets committed; the mobile key used for the runtime test was injected only into the uncommitted working tree and reverted.

Link to Devin session: https://app.devin.ai/sessions/c3b6a36dd8f2496580fc709886c15915
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line SDK API migration in the sample app’s startup path; no auth, data, or dependency version changes.
> 
> **Overview**
> Replaces the deprecated three-argument `LDClient.init` in `MainApplication` with the SDK-recommended overload that passes **`5`** as `startWaitSeconds`, so app startup can block briefly while the client fetches fresh flag values.
> 
> Inline comments document that initialization may time out after five seconds while the client remains usable with cached values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b4cfd45000d85199a5ae36673c6f019999daf56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->